### PR TITLE
Add pdf-service docker image

### DIFF
--- a/bin/start-local-environment.sh
+++ b/bin/start-local-environment.sh
@@ -4,4 +4,5 @@ COMPOSE_FILES="-f docker-compose.yml -f docker-compose.local.yml"
 docker-compose ${COMPOSE_FILES} up ${@} -d authentication-web \
                                            idam-api \
                                            fees-api \
-                                           draft-store-api
+                                           draft-store-api \
+                                           pdf-service-api

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -36,6 +36,9 @@ services:
     service-auth-provider-api:
       ports:
         - 4552:8080
+    pdf-service-api:
+      ports:
+        - 5500:5500
 
 volumes:
   draft-store-database-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,8 @@ services:
           condition: service_healthy
         service-auth-provider-api:
           condition: service_started
+        pdf-service-api:
+          condition: service_healthy
       networks:
         default:
           aliases:
@@ -131,3 +133,14 @@ services:
         - auth.provider.service.server.jwtKey=wThK0f0/lh3FlxFcL4xUWDMI5C1J9KyQBgXV4wseh1e5J1uYJIjvTvArHxQDrYoHJ23xFxjHkOnvNbR5dXRoxA==
         - auth.provider.service.server.microserviceKeys.cmc=AAAAAAAAAAAAAAAA
         - auth.provider.service.testing-support.enabled=true
+    pdf-service-api:
+      image: docker.artifactory.reform.hmcts.net/cmc/pdf-service-api
+      environment:
+        - ROOT_APPENDER
+        - JSON_CONSOLE_PRETTY_PRINT
+        - ROOT_LOGGING_LEVEL
+        - REFORM_SERVICE_NAME
+        - REFORM_TEAM
+        - REFORM_ENVIRONMENT
+      healthcheck:
+        retries: 20


### PR DESCRIPTION
This PR adds pdf-service to legal-integration-tests. This is required for the sealed claim Pdf generation. This is non breaking change.