### PR TITLE
Update fees-api image to use latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
         - CLAIM_STORE_DB_USERNAME=claimstore
         - CLAIM_STORE_DB_PASSWORD=claimstore
     fees-api:
-      image: docker.artifactory.reform.hmcts.net/fees-register/fees-api:33328e91ec54cbf4dbc9f52fe56f3712fe20a331
+      image: docker.artifactory.reform.hmcts.net/fees-register/fees-api
       healthcheck:
         retries: 20
       environment:


### PR DESCRIPTION
This PR updates the fees-api docker image to make use of unspecified endpoint. This is not a breaking change.